### PR TITLE
make all local imports relative

### DIFF
--- a/classes/ActionTabRADOLANAdder.py
+++ b/classes/ActionTabRADOLANAdder.py
@@ -16,10 +16,10 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from qgis.PyQt.QtCore    import QDateTime
 
 # own classes:
-from ActionTabBase      import ActionTabBase         # base class
-from NumpyRadolanAdder  import NumpyRadolanAdder
-from GDALProcessing     import GDALProcessing
-from LayerLoader        import LayerLoader
+from .ActionTabBase      import ActionTabBase         # base class
+from .NumpyRadolanAdder  import NumpyRadolanAdder
+from .GDALProcessing     import GDALProcessing
+from .LayerLoader        import LayerLoader
 
 """
 The format of date and datetime is different from the format of QDate and QDateTime,

--- a/classes/ActionTabRADOLANLoader.py
+++ b/classes/ActionTabRADOLANLoader.py
@@ -14,12 +14,12 @@ from qgis.PyQt.QtCore    import QSettings
 from qgis.PyQt.QtWidgets import QFileDialog, QMessageBox, QAction
 
 # own classes:
-from ActionTabBase      import ActionTabBase         # base class
-from NumpyRadolanReader import NumpyRadolanReader    # Input: read RADOLAN binary file
-from ASCIIGridWriter    import ASCIIGridWriter       # Output 1: write ESRI ASCII Grid
-from GDALProcessing     import GDALProcessing        # Output 2: write GeoTIFF
-from Model import test_product_get_id    # import a function
-from LayerLoader        import LayerLoader
+from .ActionTabBase      import ActionTabBase         # base class
+from .NumpyRadolanReader import NumpyRadolanReader    # Input: read RADOLAN binary file
+from .ASCIIGridWriter    import ASCIIGridWriter       # Output 1: write ESRI ASCII Grid
+from .GDALProcessing     import GDALProcessing        # Output 2: write GeoTIFF
+from .Model import test_product_get_id    # import a function
+from .LayerLoader        import LayerLoader
 
 
 

--- a/classes/ActionTabRegnie.py
+++ b/classes/ActionTabRegnie.py
@@ -11,10 +11,10 @@ from pathlib import Path
 from qgis.PyQt.QtWidgets import QFileDialog
 
 # own classes:
-from ActionTabBase  import ActionTabBase         # base class
-from LayerLoader    import LayerLoader
-from Regnie         import Regnie
-import regnie2raster as r2r
+from .ActionTabBase  import ActionTabBase         # base class
+from .LayerLoader    import LayerLoader
+from .Regnie         import Regnie
+from . import regnie2raster as r2r
 
 class ActionTabRegnie(ActionTabBase):
     '''

--- a/classes/Model.py
+++ b/classes/Model.py
@@ -24,10 +24,10 @@ from qgis.core import QgsApplication, QgsProject, QgsVectorLayer
 from qgis.core import QgsCoordinateReferenceSystem, QgsLayerTreeGroup
 
 
-from NumpyRadolanReader import NumpyRadolanReader
+from .NumpyRadolanReader import NumpyRadolanReader
 
-import def_products       # File 'def_products.py'
-import def_projections    # File 'def_projections.py'
+from . import def_products       # File 'def_products.py'
+from . import def_projections    # File 'def_projections.py'
 CONFIG_NAME = "config.ini"
 
 

--- a/classes/NumpyRadolanAdder.py
+++ b/classes/NumpyRadolanAdder.py
@@ -13,8 +13,8 @@ import numpy as np
 import warnings
 import re
 
-from NumpyRadolanReader import NumpyRadolanReader    # Input
-from ASCIIGridWriter    import ASCIIGridWriter       # Output
+from .NumpyRadolanReader import NumpyRadolanReader    # Input
+from .ASCIIGridWriter    import ASCIIGridWriter       # Output
 
 
 

--- a/classes/SettingsTab.py
+++ b/classes/SettingsTab.py
@@ -14,7 +14,7 @@ from qgis.core           import QgsProject
 from qgis.PyQt.QtWidgets import QFileDialog
 
 # own classes:
-from ActionTabBase import ActionTabBase         # base class
+from .ActionTabBase import ActionTabBase         # base class
 
 
 

--- a/classes/regnie2raster.py
+++ b/classes/regnie2raster.py
@@ -23,7 +23,7 @@ import numpy as np
 from osgeo import gdal
 from osgeo import osr
 
-from Regnie import Regnie
+from .Regnie import Regnie
 
 def regnie2raster(file_regnie: Path, file_raster: Path) -> None:
     """

--- a/radolan2map.py
+++ b/radolan2map.py
@@ -37,14 +37,12 @@ from console import console    # show python console automatically
 
 # Eigene Klassen
 # .........................................................
-class_path = Path(__file__).parent / 'classes'
-sys.path.append(str(class_path))    # directory of further classes
-from gui import DockWidget
-from Model import Model
-from ActionTabRADOLANLoader import ActionTabRADOLANLoader
-from ActionTabRADOLANAdder  import ActionTabRADOLANAdder
-from ActionTabRegnie        import ActionTabRegnie
-from SettingsTab            import SettingsTab
+from .classes.gui import DockWidget
+from .classes.Model import Model
+from .classes.ActionTabRADOLANLoader import ActionTabRADOLANLoader
+from .classes.ActionTabRADOLANAdder  import ActionTabRADOLANAdder
+from .classes.ActionTabRegnie        import ActionTabRegnie
+from .classes.SettingsTab            import SettingsTab
 # .........................................................
 
 


### PR DESCRIPTION
This fixes #11 by avoiding `sys.path.append()` and instead using only relative imports for local modules and classes.

Changes are based on the latest version available on GitHub (v1.6). I would be happy to adapt to v1.7 if that is pushed.